### PR TITLE
refactor(result): rename err to error and update package exports

### DIFF
--- a/packages/result/package.json
+++ b/packages/result/package.json
@@ -1,33 +1,44 @@
 {
-    "name": "@ztils/result",
-    "description": "Result utilities",
-    "type": "module",
-    "version": "0.4.0",
-    "license": "MIT",
-    "repository": {
-      "type": "git",
-      "url": "https://github.com/johngerome/ztils"
+  "name": "@ztils/result",
+  "description": "Result utilities",
+  "type": "module",
+  "version": "0.4.0",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/johngerome/ztils"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "dev": "tsc --watch",
+    "build": "tsc",
+    "check-types": "tsc --noEmit",
+    "test": "vitest"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
     },
-    "publishConfig": {
-      "access": "public"
+    "./ok": {
+      "import": "./dist/ok.js",
+      "types": "./dist/ok.d.ts"
     },
-    "main": "./dist/index.js",
-    "types": "./dist/index.d.ts",
-    "scripts": {
-      "dev": "tsc --watch",
-      "build": "tsc",
-      "check-types": "tsc --noEmit",
-      "test": "vitest"
+    "./error": {
+      "import": "./dist/error.js",
+      "types": "./dist/error.d.ts"
     },
-    "exports": {
-      ".": {
-        "import": "./dist/index.js",
-        "types": "./dist/index.d.ts"
-      }
-    },
-    "devDependencies": {
-      "@repo/typescript-config": "workspace:*",
-      "typescript": "5.8.2"
+    "./safe": {
+      "import": "./dist/safe.js",
+      "types": "./dist/safe.d.ts"
     }
+  },
+  "devDependencies": {
+    "@repo/typescript-config": "workspace:*",
+    "typescript": "5.8.2"
   }
-  
+}

--- a/packages/result/src/error.test.ts
+++ b/packages/result/src/error.test.ts
@@ -1,30 +1,30 @@
 import { describe, it, expect } from "vitest";
-import { err } from "./error.js";
+import { error } from "./error.js";
 
-describe("err", () => {
+describe("error", () => {
   it("should return an object", () => {
     const testError = new Error("Test error");
-    const result = err(testError);
+    const result = error(testError);
     expect(typeof result).toBe("object");
     expect(result).not.toBeNull();
   });
 
   it("should return an object with the correct error property", () => {
     const testError = new Error("Something went wrong");
-    const result = err(testError);
+    const result = error(testError);
     expect(result.error).toBe(testError);
     expect(result.error.message).toBe("Something went wrong");
   });
 
   it("should return an object with the data property set to null", () => {
     const testError = new Error("Another error");
-    const result = err(testError);
+    const result = error(testError);
     expect(result.data).toBeNull();
   });
 
   it("should handle a standard Error object", () => {
     const testError = new Error("Standard error message");
-    const result = err(testError);
+    const result = error(testError);
     expect(result.error).toBeInstanceOf(Error);
     expect(result.error.message).toBe("Standard error message");
     expect(result.data).toBeNull();
@@ -42,7 +42,7 @@ describe("err", () => {
 
   it("should handle a custom Error object", () => {
     const testCustomError = new CustomError("Custom error with code", 123);
-    const result = err(testCustomError);
+    const result = error(testCustomError);
     expect(result.error).toBeInstanceOf(CustomError);
     expect(result.error.message).toBe("Custom error with code");
     expect((result.error as CustomError).code).toBe(123);

--- a/packages/result/src/error.ts
+++ b/packages/result/src/error.ts
@@ -3,7 +3,7 @@ export type ErrResult = {
   data: null;
 };
 
-export function err(error: Error): ErrResult {
+export function error(error: Error): ErrResult {
   return {
     error,
     data: null,

--- a/packages/result/src/safe.ts
+++ b/packages/result/src/safe.ts
@@ -1,5 +1,5 @@
 import type { Ok, ErrResult } from "./index.js";
-import { ok, err } from "./index.js";
+import { ok, error } from "./index.js";
 
 type Result<TOutput> = Ok<TOutput> | ErrResult;
 
@@ -9,7 +9,7 @@ export async function safe<TOutput>(
   try {
     const output = await promise;
     return ok(output);
-  } catch (error) {
-    return err(error instanceof Error ? error : new Error(String(error)));
+  } catch (err) {
+    return error(err instanceof Error ? err : new Error(String(err)));
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed the function previously called `err` to `error` throughout the package for consistency.
  - Updated test descriptions and imports to use the new function name.

- **Chores**
  - Improved package configuration with explicit entry points, enhanced exports, and additional publishing and development scripts in the package metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->